### PR TITLE
Make forum signature banner better to copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,7 @@ https://imageshack.com/i/pobYCf67p
 
 
 add this code to your forum signiture to support scratch tools :D
+
+```
 [url=https://spazestudios.github.io/Scratch-Tools/][img]https://assets.scratch.mit.edu/get_image/.%2E/1319b3776c231c7d42732747b822bf5a.svg[/img][/url]
+```


### PR DESCRIPTION
This pull request removes the automatic link and also makes it like [code] tags on the Scratch forums.